### PR TITLE
use setImmediate instead of process.nextTick

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var mutexify = function() {
   var acquire = function (fn) {
     if (used) return queue.push(fn)
     used = fn
-    process.nextTick(call)
+    setImmediate(call)
     return 0
   }
 


### PR DESCRIPTION
Because process.nextTick is deprecated:

*However, there are programs out in the wild that use recursive calls to process.nextTick to avoid pre-empting the I/O event loop for long-running jobs. In order to avoid breaking horribly right away, Node will now print a deprecation warning, and ask you to use setImmediate for these kinds of tasks instead.*

http://blog.nodejs.org/2013/03/11/node-v0-10-0-stable/