### PR TITLE
Add note about lock request order

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm install mutexify
 
 [![build status](http://img.shields.io/travis/mafintosh/mutexify.svg?style=flat)](http://travis-ci.org/mafintosh/mutexify)
 
-Hasn't this been done before? Yes but the specific semantics of this made some of my code simpler
+Hasn't this been done before? Yes, but the specific semantics of this made some of my code simpler.
 
 ## Usage
 
@@ -40,6 +40,8 @@ var write = function(data, cb) {
   }) 
 }
 ```
+
+`mutexify` guarantees that the order that a mutex was requested in is the order that access will be given.
 
 ## License
 


### PR DESCRIPTION
I was using this module the other day and didn't realize that a queue is maintained internally to preserve request order on the lock. I didn't assume this was a given, so I thought it'd be nice to let others know about, too.